### PR TITLE
version bump: 0.16.0 -> 1.11.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: yaml-language-server
-version: '0.16.0'
+version: '1.11.0'
 summary: YAML Language Server
 description: |
   Features


### PR DESCRIPTION
Just a simple version bump.

The existing snap release targets `yaml-language-server` v0.16.0 (dated 2021-03-04). Version v1.11.0 is dated 2023-01-09.