### PR TITLE
Update yaml-lsp and snap to core22

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,5 +41,6 @@ parts:
     npm-node-version: 20.11.0
     override-build: |
       snapcraftctl build
+      corepack yarn install
       corepack yarn run build
       cp -r out $SNAPCRAFT_PART_INSTALL

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: yaml-language-server
-version: '1.11.0'
+version: '1.14.0'
 summary: YAML Language Server
 description: |
   Features
@@ -23,7 +23,7 @@ description: |
 
 grade: stable
 confinement: strict
-base: core18
+base: core22
 
 apps:
   yaml-language-server:
@@ -34,10 +34,11 @@ apps:
 
 parts:
   yaml-language-server:
-    plugin: nodejs
+    plugin: npm
     source: https://github.com/redhat-developer/yaml-language-server.git
     source-tag: $SNAPCRAFT_PROJECT_VERSION
-    nodejs-version: 16.19.0
+    npm-include-node: true
+    npm-node-version: 20.11.0
     override-build: |
       snapcraftctl build
       ../npm/bin/yarn run build

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,5 +41,5 @@ parts:
     npm-node-version: 20.11.0
     override-build: |
       snapcraftctl build
-      ../npm/bin/yarn run build
+      corepack yarn run build
       cp -r out $SNAPCRAFT_PART_INSTALL


### PR DESCRIPTION
These patches should upgrade the YAML LSP, Node.js to LTS and snap to core22.
It builds using GitHub Actions, but I can't try it locally, since I can't figure out how to build for Arm via GH Actions.

Sadly, I can't figure out how to run Snapcraft locally, either.
Maybe it has something to do with me being on Arm or using Fedora with Selinux enabled?

Do you think it is possible to remove the home plug to further sandbox the LSP? 

I suspect the Snap works, but it would need some testing.

Have a nice day ^^